### PR TITLE
Add SQLite and libSQL database backend support

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,9 +10,9 @@ Haitatsu is a simple email server written in Go. It receives and stores mail, ex
 - Relay delivery with exponential backoff over roughly two days, permanent failure notifications
 - REST API with cursor pagination, constant-time service token auth
 - TLS from automatic ACME certificates, or read straight out of a certmagic-layout S3 bucket that something else (such as Caddy) already keeps current, for any number of hostnames
-- App passwords for protocol access, with login throttling shared across nodes through Postgres
+- App passwords for protocol access, with database-backed login throttling shared across nodes
 - Quota accounting that tracks deletes and expunges, with a recompute endpoint
-- PostgreSQL for metadata, S3-compatible storage for message blobs, versioned migrations
+- PostgreSQL, SQLite, or remote libSQL for metadata, S3-compatible storage for message blobs, versioned migrations
 - Pkl configuration with hot reload of spam, relay, webhook, notification, API token, and limits settings
 
 Mailbox users do not call the REST API directly. Integrate from your own backend using a configured service token. End users authenticate to IMAP and SMTP with app passwords.
@@ -21,7 +21,7 @@ Mailbox users do not call the REST API directly. Integrate from your own backend
 
 - Go 1.26 or later
 - [Pkl](https://pkl-lang.org/) (for local runs outside Docker)
-- PostgreSQL
+- PostgreSQL, a writable local directory for SQLite, or a libSQL server
 - S3-compatible object storage (MinIO works for development)
 
 ## Configuration
@@ -34,7 +34,53 @@ cp haitatsu.example.pkl haitatsu.pkl
 
 The server reads config from `/etc/haitatsu/haitatsu.pkl` by default and refuses to start if nothing is there. Override with `-config path/to/haitatsu.pkl`. The Docker image ships no config, so mount one at that path.
 
-Any field can read from the environment with `read("env:NAME")`, and `read?("env:NAME") ?? ""` makes it optional. The example config does this for every secret (Postgres DSN, S3 keys, service token, relay credentials, webhook secret, notification render secret, certificate-bucket keys, Axiom token) and sets `instance_name` from `HOSTNAME`, so a deployment is the committed file plus a handful of environment variables. See `deploy/README.md` for the list.
+Any field can read from the environment with `read("env:NAME")`, and `read?("env:NAME") ?? ""` makes it optional. The example config does this for every secret, including the database DSN and libSQL auth token, and sets `instance_name` from `HOSTNAME`. See `deploy/README.md` for the list.
+
+## Database backends
+
+PostgreSQL remains the default. The old `postgres { dsn = "..." }` block is still accepted, but new configurations should use `database`:
+
+```pkl
+database {
+  driver = "postgres"
+  dsn = "postgres://haitatsu:password@localhost:5432/haitatsu"
+  auth_token = ""
+}
+```
+
+For a local SQLite file:
+
+```pkl
+database {
+  driver = "sqlite"
+  dsn = "file:/var/lib/haitatsu/haitatsu.db"
+  auth_token = ""
+}
+```
+
+Haitatsu enables foreign keys, WAL mode, and a five-second busy timeout for local SQLite connections. Keep the database on a local persistent volume, not a network filesystem.
+
+For Turso Cloud:
+
+```pkl
+database {
+  driver = "libsql"
+  dsn = "libsql://database-name-organization.turso.io"
+  auth_token = read("env:HAITATSU_DATABASE_AUTH_TOKEN")
+}
+```
+
+Self-hosted sqld accepts `http://`, `https://`, `ws://`, and `wss://` URLs. An unauthenticated local server can use:
+
+```pkl
+database {
+  driver = "libsql"
+  dsn = "http://sqld:8080"
+  auth_token = ""
+}
+```
+
+SQLite and libSQL use FTS5 for the REST message search endpoint. PostgreSQL keeps its GIN-backed full-text index.
 
 ## Local development
 
@@ -66,10 +112,11 @@ Health checks: `GET /health`, `GET /ready`. Metrics: `GET /metrics`.
 
 ## Configuration reference
 
-Listener addresses, Postgres, S3, TLS, and worker enablement require a restart. Everything else reloads on `SIGHUP` or `POST /api/v1/admin/reload`.
+Listener addresses, database settings, S3, TLS, and worker enablement require a restart. Everything else reloads on `SIGHUP` or `POST /api/v1/admin/reload`.
 
 | Block | Keys |
 |-------|------|
+| `database` | `driver`, `dsn`, `auth_token` |
 | `limits` | `max_message_size_bytes`, `max_inbound_recipients`, `max_submission_recipients`, `max_connections_per_ip`, `inbound_messages_per_minute_per_ip`, `default_outbound_per_hour`, `default_outbound_per_day`, `default_outbound_recipients_per_message` |
 | `relay` | `addr`, `username`, `password`, `from_host`, `max_attempts`, `max_retry_minutes` |
 | `webhooks` | `default_timeout_seconds`, `secret`, `endpoints`, `max_attempts` |
@@ -86,7 +133,7 @@ Every list endpoint accepts `limit` (max 100) and `cursor`. The response include
 
 ## Multi-node
 
-IMAP IDLE notifications and login throttling are shared between nodes through Postgres (`LISTEN/NOTIFY` and the `auth_lockouts` table), so any number of Haitatsu processes can serve the same database.
+IMAP IDLE notifications and login throttling are shared between nodes. PostgreSQL uses `LISTEN/NOTIFY`; libSQL uses a short-lived database change log that is polled every 250 milliseconds. Local SQLite is intended for one Haitatsu process. PostgreSQL remains the better choice for sustained concurrent writes.
 
 Stop the stack with `task compose:down`. Reset volumes with `task compose:reset`.
 

--- a/deploy/README.md
+++ b/deploy/README.md
@@ -24,7 +24,10 @@ the container environment through `read("env:...")`, so the stack's
 
 | Variable | Used by |
 |----------|---------|
-| `HAITATSU_POSTGRES_DSN` | `postgres.dsn` |
+| `HAITATSU_DATABASE_DRIVER` | `database.driver` (optional, defaults to `postgres`) |
+| `HAITATSU_DATABASE_DSN` | `database.dsn` (falls back to `HAITATSU_POSTGRES_DSN`) |
+| `HAITATSU_DATABASE_AUTH_TOKEN` | `database.auth_token` (libSQL only) |
+| `HAITATSU_POSTGRES_DSN` | Legacy fallback for `database.dsn` |
 | `HAITATSU_S3_ACCESS_KEY` | `s3.access_key_id` |
 | `HAITATSU_S3_SECRET_KEY` | `s3.secret_access_key` |
 | `HAITATSU_SERVICE_TOKEN` | `api.service_token` |

--- a/go.mod
+++ b/go.mod
@@ -16,6 +16,7 @@ require (
 	github.com/minio/minio-go/v7 v7.1.0
 	github.com/oklog/ulid/v2 v2.1.1
 	github.com/prometheus/client_golang v1.23.2
+	github.com/tursodatabase/libsql-client-go v0.0.0-20260528064733-9d5d30a29a60
 	golang.org/x/crypto v0.51.0
 	golang.org/x/net v0.54.0
 	modernc.org/sqlite v1.53.0
@@ -25,6 +26,7 @@ require (
 	ariga.io/atlas v0.36.2-0.20250730182955-2c6300d0a3e1 // indirect
 	github.com/agext/levenshtein v1.2.3 // indirect
 	github.com/andybalholm/brotli v1.2.1 // indirect
+	github.com/antlr4-go/antlr/v4 v4.13.0 // indirect
 	github.com/apparentlymart/go-textseg/v15 v15.0.0 // indirect
 	github.com/beorn7/perks v1.0.1 // indirect
 	github.com/bmatcuk/doublestar v1.3.4 // indirect
@@ -33,6 +35,7 @@ require (
 	github.com/clipperhouse/displaywidth v0.6.2 // indirect
 	github.com/clipperhouse/stringish v0.1.1 // indirect
 	github.com/clipperhouse/uax29/v2 v2.3.0 // indirect
+	github.com/coder/websocket v1.8.12 // indirect
 	github.com/dustin/go-humanize v1.0.1 // indirect
 	github.com/fatih/color v1.18.0 // indirect
 	github.com/go-ini/ini v1.67.0 // indirect
@@ -86,6 +89,7 @@ require (
 	go.uber.org/zap/exp v0.3.0 // indirect
 	go.yaml.in/yaml/v2 v2.4.2 // indirect
 	go.yaml.in/yaml/v3 v3.0.4 // indirect
+	golang.org/x/exp v0.0.0-20240325151524-a685a6edb6d8 // indirect
 	golang.org/x/mod v0.36.0 // indirect
 	golang.org/x/sync v0.20.0 // indirect
 	golang.org/x/sys v0.44.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -10,6 +10,8 @@ github.com/agext/levenshtein v1.2.3 h1:YB2fHEn0UJagG8T1rrWknE3ZQzWM06O8AMAatNn7l
 github.com/agext/levenshtein v1.2.3/go.mod h1:JEDfjyjHDjOF/1e4FlBE/PkbqA9OfWu2ki2W0IB5558=
 github.com/andybalholm/brotli v1.2.1 h1:R+f5xP285VArJDRgowrfb9DqL18yVK0gKAW/F+eTWro=
 github.com/andybalholm/brotli v1.2.1/go.mod h1:rzTDkvFWvIrjDXZHkuS16NPggd91W3kUSvPlQ1pLaKY=
+github.com/antlr4-go/antlr/v4 v4.13.0 h1:lxCg3LAv+EUK6t1i0y1V6/SLeUi0eKEKdhQAlS8TVTI=
+github.com/antlr4-go/antlr/v4 v4.13.0/go.mod h1:pfChB/xh/Unjila75QW7+VU4TSnWnnk9UTnmpPaOR2g=
 github.com/apparentlymart/go-textseg/v15 v15.0.0 h1:uYvfpb3DyLSCGWnctWKGj857c6ew1u1fNQOlOtuGxQY=
 github.com/apparentlymart/go-textseg/v15 v15.0.0/go.mod h1:K8XmNZdhEBkdlyDdvbmmsvpAG721bKi0joRfFdHIWJ4=
 github.com/apple/pkl-go v0.13.2 h1:UCug0neH9Ufw0Loujosv5/UUXEXzY76HXbjqYqlPSGI=
@@ -30,6 +32,8 @@ github.com/clipperhouse/stringish v0.1.1 h1:+NSqMOr3GR6k1FdRhhnXrLfztGzuG+VuFDfa
 github.com/clipperhouse/stringish v0.1.1/go.mod h1:v/WhFtE1q0ovMta2+m+UbpZ+2/HEXNWYXQgCt4hdOzA=
 github.com/clipperhouse/uax29/v2 v2.3.0 h1:SNdx9DVUqMoBuBoW3iLOj4FQv3dN5mDtuqwuhIGpJy4=
 github.com/clipperhouse/uax29/v2 v2.3.0/go.mod h1:Wn1g7MK6OoeDT0vL+Q0SQLDz/KpfsVRgg6W7ihQeh4g=
+github.com/coder/websocket v1.8.12 h1:5bUXkEPPIbewrnkU8LTCLVaxi4N4J8ahufH2vlo4NAo=
+github.com/coder/websocket v1.8.12/go.mod h1:LNVeNrXQZfe5qhS9ALED3uA+l5pPqvwXg3CKoDBB2gs=
 github.com/cpuguy83/go-md2man/v2 v2.0.2/go.mod h1:tgQtvFlXSQOSOSIRvRPT7W67SCa46tRHOmNcaadrF8o=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
@@ -172,6 +176,8 @@ github.com/stretchr/testify v1.11.1 h1:7s2iGBzp5EwR7/aIZr8ao5+dra3wiQyKjjFuvgVKu
 github.com/stretchr/testify v1.11.1/go.mod h1:wZwfW3scLgRK+23gO65QZefKpKQRnfz6sD981Nm4B6U=
 github.com/tinylib/msgp v1.6.4 h1:mOwYbyYDLPj35mkA2BjjYejgJk9BuHxDdvRnb6v2ZcQ=
 github.com/tinylib/msgp v1.6.4/go.mod h1:RSp0LW9oSxFut3KzESt5Voq4GVWyS+PSulT77roAqEA=
+github.com/tursodatabase/libsql-client-go v0.0.0-20260528064733-9d5d30a29a60 h1:TfQEwhr0Q9t+Bgs0TNk2eHZ9EGD107Mimic0kcoGS1M=
+github.com/tursodatabase/libsql-client-go v0.0.0-20260528064733-9d5d30a29a60/go.mod h1:08inkKyguB6CGGssc/JzhmQWwBgFQBgjlYFjxjRh7nU=
 github.com/valyala/bytebufferpool v1.0.0 h1:GqA5TC/0021Y/b9FG4Oi9Mr3q7XYx6KllzawFIhcdPw=
 github.com/valyala/bytebufferpool v1.0.0/go.mod h1:6bBcMArwyJ5K/AmCkWv1jt77kVWyCJ6HpOuEn7z0Csc=
 github.com/valyala/fasthttp v1.70.0 h1:LAhMGcWk13QZWm85+eg8ZBNbrq5mnkWFGbHMUJHIdXA=
@@ -213,6 +219,8 @@ golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACk
 golang.org/x/crypto v0.0.0-20210921155107-089bfa567519/go.mod h1:GvvjBRRGRdwPK5ydBHafDWAxML/pGHZbMvKqRZ5+Abc=
 golang.org/x/crypto v0.51.0 h1:IBPXwPfKxY7cWQZ38ZCIRPI50YLeevDLlLnyC5wRGTI=
 golang.org/x/crypto v0.51.0/go.mod h1:8AdwkbraGNABw2kOX6YFPs3WM22XqI4EXEd8g+x7Oc8=
+golang.org/x/exp v0.0.0-20240325151524-a685a6edb6d8 h1:aAcj0Da7eBAtrTp03QXWvm88pSyOt+UgdZw2BFZ+lEw=
+golang.org/x/exp v0.0.0-20240325151524-a685a6edb6d8/go.mod h1:CQ1k9gNrJ50XIzaKCRR2hssIjF07kZFEiieALBM/ARQ=
 golang.org/x/mod v0.6.0-dev.0.20220419223038-86c51ed26bb4/go.mod h1:jJ57K6gSWd91VN4djpZkiMVwK6gcyfeH4XE8wZrZaV4=
 golang.org/x/mod v0.8.0/go.mod h1:iBbtSCu2XBx23ZKBPSOrRkjjQPZFPuis4dIYUhu/chs=
 golang.org/x/mod v0.36.0 h1:JJjpVx6myfUsUdAzZuOSTTmRE0PfZeNWzzvKrP7amb4=

--- a/haitatsu.compose.pkl
+++ b/haitatsu.compose.pkl
@@ -30,8 +30,10 @@ relay {
   max_retry_minutes = 240
 }
 
-postgres {
+database {
+  driver = "postgres"
   dsn = "postgres://haitatsu:woof@postgres:5432/haitatsu?sslmode=disable"
+  auth_token = ""
 }
 
 s3 {

--- a/haitatsu.example.pkl
+++ b/haitatsu.example.pkl
@@ -30,8 +30,10 @@ relay {
   max_retry_minutes = 240
 }
 
-postgres {
-  dsn = read("env:HAITATSU_POSTGRES_DSN")
+database {
+  driver = read?("env:HAITATSU_DATABASE_DRIVER") ?? "postgres"
+  dsn = read?("env:HAITATSU_DATABASE_DSN") ?? read("env:HAITATSU_POSTGRES_DSN")
+  auth_token = read?("env:HAITATSU_DATABASE_AUTH_TOKEN") ?? ""
 }
 
 s3 {

--- a/internal/api/messages.go
+++ b/internal/api/messages.go
@@ -6,6 +6,7 @@ import (
 	"strings"
 	"time"
 
+	"entgo.io/ent/dialect"
 	entsql "entgo.io/ent/dialect/sql"
 	"github.com/gofiber/fiber/v3"
 
@@ -452,13 +453,9 @@ func (h *Handler) applyMailboxSearch(c fiber.Ctx, query *ent.MailboxMessageQuery
 }
 
 func (h *Handler) searchMessageIDs(c fiber.Ctx, search messageSearch) ([]string, error) {
-	where, args := messageSearchWhere(search)
-	if len(where) == 0 {
+	query, args := messageSearchQuery(search, h.dialect)
+	if query == "" {
 		return nil, nil
-	}
-	query := "SELECT id FROM messages WHERE " + strings.Join(where, " AND ") + " ORDER BY created_at DESC"
-	if len(search.Terms) > 0 {
-		query = "SELECT id FROM messages, websearch_to_tsquery('english', $1) query WHERE " + strings.Join(where, " AND ") + " ORDER BY ts_rank(" + messageSearchVector + ", query) DESC, created_at DESC"
 	}
 	rows, err := h.db.QueryContext(c.Context(), query, args...)
 	if err != nil {
@@ -477,39 +474,99 @@ func (h *Handler) searchMessageIDs(c fiber.Ctx, search messageSearch) ([]string,
 	return ids, rows.Err()
 }
 
-func messageSearchWhere(search messageSearch) ([]string, []any) {
+func messageSearchQuery(search messageSearch, dbDialect string) (string, []any) {
+	where, args := messageSearchWhere(search, dbDialect)
+	if len(where) == 0 {
+		return "", nil
+	}
+	query := "SELECT id FROM messages WHERE " + strings.Join(where, " AND ") + " ORDER BY created_at DESC"
+	if len(search.Terms) > 0 && dbDialect == dialect.Postgres {
+		query = "SELECT id FROM messages, websearch_to_tsquery('english', $1) query WHERE " + strings.Join(where, " AND ") + " ORDER BY ts_rank(" + messageSearchVector + ", query) DESC, created_at DESC"
+	} else if sqliteFTSQuery(search.Terms) != "" {
+		query = "SELECT messages.id FROM messages JOIN messages_search ON messages_search.message_id = messages.id WHERE " + strings.Join(where, " AND ") + " ORDER BY bm25(messages_search), messages.created_at DESC"
+	}
+	return query, args
+}
+
+func messageSearchWhere(search messageSearch, dbDialect string) ([]string, []any) {
 	var where []string
 	var args []any
-	add := func(clause string, value any) {
+	addPostgres := func(clause string, value any) {
 		args = append(args, value)
 		where = append(where, fmt.Sprintf(clause, len(args)))
 	}
-	if len(search.Terms) > 0 {
+	addSQLite := func(clause string, value any) {
+		args = append(args, value)
+		where = append(where, clause)
+	}
+	if len(search.Terms) > 0 && dbDialect == dialect.Postgres {
 		args = append(args, strings.Join(search.Terms, " "))
 		where = append(where, messageSearchVector+" @@ query")
+	} else if terms := sqliteFTSQuery(search.Terms); terms != "" {
+		addSQLite("messages_search MATCH ?", terms)
 	}
 	if search.From != "" {
-		add("from_addresses::text ILIKE '%%' || $%d || '%%'", search.From)
+		if dbDialect == dialect.Postgres {
+			addPostgres("from_addresses::text ILIKE '%%' || $%d || '%%'", search.From)
+		} else {
+			addSQLite("lower(CAST(messages.from_addresses AS TEXT)) LIKE '%' || lower(?) || '%'", search.From)
+		}
 	}
 	if search.To != "" {
-		add("to_addresses::text ILIKE '%%' || $%d || '%%'", search.To)
+		if dbDialect == dialect.Postgres {
+			addPostgres("to_addresses::text ILIKE '%%' || $%d || '%%'", search.To)
+		} else {
+			addSQLite("lower(CAST(messages.to_addresses AS TEXT)) LIKE '%' || lower(?) || '%'", search.To)
+		}
 	}
 	if search.CC != "" {
-		add("cc_addresses::text ILIKE '%%' || $%d || '%%'", search.CC)
+		if dbDialect == dialect.Postgres {
+			addPostgres("cc_addresses::text ILIKE '%%' || $%d || '%%'", search.CC)
+		} else {
+			addSQLite("lower(CAST(messages.cc_addresses AS TEXT)) LIKE '%' || lower(?) || '%'", search.CC)
+		}
 	}
 	if search.Subject != "" {
-		add("subject ILIKE '%%' || $%d || '%%'", search.Subject)
+		if dbDialect == dialect.Postgres {
+			addPostgres("subject ILIKE '%%' || $%d || '%%'", search.Subject)
+		} else {
+			addSQLite("lower(messages.subject) LIKE '%' || lower(?) || '%'", search.Subject)
+		}
 	}
 	if search.HasAttachment {
-		where = append(where, "jsonb_array_length(attachments) > 0")
+		if dbDialect == dialect.Postgres {
+			where = append(where, "jsonb_array_length(attachments) > 0")
+		} else {
+			where = append(where, "json_array_length(messages.attachments) > 0")
+		}
 	}
 	if search.After != nil {
-		add("coalesce(date, created_at) >= $%d", *search.After)
+		if dbDialect == dialect.Postgres {
+			addPostgres("coalesce(date, created_at) >= $%d", *search.After)
+		} else {
+			addSQLite("datetime(coalesce(messages.date, messages.created_at)) >= datetime(?)", *search.After)
+		}
 	}
 	if search.Before != nil {
-		add("coalesce(date, created_at) <= $%d", *search.Before)
+		if dbDialect == dialect.Postgres {
+			addPostgres("coalesce(date, created_at) <= $%d", *search.Before)
+		} else {
+			addSQLite("datetime(coalesce(messages.date, messages.created_at)) <= datetime(?)", *search.Before)
+		}
 	}
 	return where, args
+}
+
+func sqliteFTSQuery(terms []string) string {
+	quoted := make([]string, 0, len(terms))
+	for _, term := range terms {
+		term = strings.TrimSpace(strings.Trim(term, `"`))
+		if term == "" {
+			continue
+		}
+		quoted = append(quoted, `"`+strings.ReplaceAll(term, `"`, `""`)+`"`)
+	}
+	return strings.Join(quoted, " AND ")
 }
 
 func searchTokens(value string) []string {

--- a/internal/api/messages_test.go
+++ b/internal/api/messages_test.go
@@ -1,9 +1,19 @@
 package api
 
-import "testing"
+import (
+	"context"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"entgo.io/ent/dialect"
+
+	"github.com/zephyraoss/haitatsu/internal/config"
+	"github.com/zephyraoss/haitatsu/internal/database"
+)
 
 func TestMessageSearchWhereTermsClause(t *testing.T) {
-	where, args := messageSearchWhere(messageSearch{Terms: []string{"inbound"}})
+	where, args := messageSearchWhere(messageSearch{Terms: []string{"inbound"}}, dialect.Postgres)
 	if len(where) != 1 {
 		t.Fatalf("where len = %d, want 1", len(where))
 	}
@@ -16,7 +26,7 @@ func TestMessageSearchWhereTermsClause(t *testing.T) {
 }
 
 func TestMessageSearchWhereFromUsesPlaceholder(t *testing.T) {
-	where, args := messageSearchWhere(messageSearch{From: "alice"})
+	where, args := messageSearchWhere(messageSearch{From: "alice"}, dialect.Postgres)
 	if len(where) != 1 {
 		t.Fatalf("where len = %d, want 1", len(where))
 	}
@@ -25,5 +35,62 @@ func TestMessageSearchWhereFromUsesPlaceholder(t *testing.T) {
 	}
 	if len(args) != 1 || args[0] != "alice" {
 		t.Fatalf("args = %#v, want [alice]", args)
+	}
+}
+
+func TestMessageSearchQueryUsesSQLiteSyntax(t *testing.T) {
+	query, args := messageSearchQuery(messageSearch{
+		Terms:         []string{"hello", `"two words"`},
+		From:          "alice",
+		HasAttachment: true,
+	}, dialect.SQLite)
+	for _, unsupported := range []string{"ILIKE", "::text", "jsonb_", "to_tsvector", "$1"} {
+		if strings.Contains(query, unsupported) {
+			t.Errorf("query contains PostgreSQL syntax %q: %s", unsupported, query)
+		}
+	}
+	if len(args) != 2 || args[0] != `"hello" AND "two words"` || args[1] != "alice" {
+		t.Fatalf("args = %#v", args)
+	}
+}
+
+func TestMessageSearchQueryRunsOnSQLite(t *testing.T) {
+	ctx := context.Background()
+	dbClient, err := database.Open(ctx, config.DatabaseConfig{Driver: "sqlite", DSN: filepath.Join(t.TempDir(), "haitatsu.db")})
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer dbClient.Close()
+	if err := dbClient.RunMigrations(ctx); err != nil {
+		t.Fatal(err)
+	}
+	message, err := dbClient.Ent().Message.Create().
+		SetTraceID("trace").
+		SetBlobKey("message.eml").
+		SetSha256("sha256").
+		SetSizeBytes(10).
+		SetSubject("Quarterly Invoice").
+		SetFromAddresses([]string{"alice@example.test"}).
+		SetAttachments([]map[string]any{{"filename": "invoice.pdf"}}).
+		Save(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	query, args := messageSearchQuery(messageSearch{Terms: []string{"invoice"}, From: "ALICE", HasAttachment: true}, dialect.SQLite)
+	rows, err := dbClient.SQL().QueryContext(ctx, query, args...)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer rows.Close()
+	if !rows.Next() {
+		t.Fatalf("expected message %s in search results", message.ID)
+	}
+	var id string
+	if err := rows.Scan(&id); err != nil {
+		t.Fatal(err)
+	}
+	if id != message.ID {
+		t.Fatalf("message id = %q, want %q", id, message.ID)
 	}
 }

--- a/internal/api/routes.go
+++ b/internal/api/routes.go
@@ -7,6 +7,7 @@ import (
 	"strconv"
 	"time"
 
+	"entgo.io/ent/dialect"
 	entsql "entgo.io/ent/dialect/sql"
 	"github.com/gofiber/fiber/v3"
 
@@ -30,6 +31,7 @@ import (
 type Handler struct {
 	client   *ent.Client
 	db       *sql.DB
+	dialect  string
 	store    MessageStore
 	mail     *mailstore.Store
 	outbound *outbound.Submission
@@ -46,7 +48,11 @@ type MessageStore interface {
 }
 
 func Register(router fiber.Router, client *ent.Client, db *sql.DB, store MessageStore, mail *mailstore.Store, outboundService *outbound.Submission, cfg *config.Holder, reloader Reloader) {
-	h := &Handler{client: client, db: db, store: store, mail: mail, outbound: outboundService, config: cfg, reloader: reloader}
+	dbDialect := dialect.Postgres
+	if cfg.Get().EffectiveDatabase().Driver != "postgres" {
+		dbDialect = dialect.SQLite
+	}
+	h := &Handler{client: client, db: db, dialect: dbDialect, store: store, mail: mail, outbound: outboundService, config: cfg, reloader: reloader}
 	v1 := router.Group("/api/v1", ServiceTokenMiddleware(func() string { return cfg.Get().API.ServiceToken }))
 
 	v1.Get("/mailboxes", h.listMailboxes)

--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -74,7 +74,7 @@ func New(ctx context.Context, opts Options) (*App, error) {
 	logger = logger.With("version", version.Version, "instance", cfg.Server.InstanceName)
 	slog.SetDefault(logger)
 
-	db, err := database.Open(ctx, cfg.Postgres)
+	db, err := database.Open(ctx, cfg.EffectiveDatabase())
 	if err != nil {
 		return nil, fmt.Errorf("open database: %w", err)
 	}
@@ -91,7 +91,7 @@ func New(ctx context.Context, opts Options) (*App, error) {
 	}
 
 	holder := config.NewHolder(cfg)
-	notifier := mailstore.NewNotifier(cfg.Server.InstanceName, database.NewChangeBus(db.SQL()))
+	notifier := mailstore.NewNotifier(cfg.Server.InstanceName, database.NewChangeBus(db.SQL(), db.Backend()))
 	mail := mailstore.New(db.Ent(), notifier)
 	runtime := &App{configPath: opts.ConfigPath, config: holder, logger: logger, database: db, storage: blobStore, notifier: notifier}
 	m := metrics.New()
@@ -103,14 +103,14 @@ func New(ctx context.Context, opts Options) (*App, error) {
 	server := httpapi.New(holder, db.Ent(), db.SQL(), blobStore, mail, submissionService, checker, m, runtime)
 	cleanupWorker := cleanup.New(db.Ent(), blobStore, mail, m)
 	eventService := events.New(db.Ent())
-	exportWorker := importexport.NewExportWorker(db.SQL(), db.Ent(), blobStore, eventService, cfg.Server.InstanceName)
-	importWorker := importexport.NewImportWorker(db.SQL(), db.Ent(), blobStore, mail, eventService, cfg.Server.InstanceName)
-	webhookWorker := webhooks.NewWorker(db.SQL(), db.Ent(), func() config.WebhookConfig { return holder.Get().Webhooks }, m, cfg.Server.InstanceName)
+	exportWorker := importexport.NewExportWorker(db.SQL(), db.Ent(), blobStore, eventService, cfg.Server.InstanceName, db.Backend())
+	importWorker := importexport.NewImportWorker(db.SQL(), db.Ent(), blobStore, mail, eventService, cfg.Server.InstanceName, db.Backend())
+	webhookWorker := webhooks.NewWorker(db.SQL(), db.Ent(), func() config.WebhookConfig { return holder.Get().Webhooks }, m, cfg.Server.InstanceName, db.Backend())
 	resolver := routing.NewResolver(db.Ent())
 	ruleEngine := rules.New(db.Ent(), mail, eventService)
 	messageService := messages.NewService(db.Ent(), blobStore, mail, eventService, ruleEngine, m, cfg.Server.PublicHostname, cfg.Server.InstanceName)
 	notificationService := notifications.New(db.Ent(), messageService, func() config.NotificationConfig { return holder.Get().Notifications }, cfg.Server.PublicHostname)
-	relayWorker := outbound.NewWorker(db.SQL(), db.Ent(), blobStore, func() config.RelayConfig { return holder.Get().Relay }, m, notificationService, cfg.Server.InstanceName)
+	relayWorker := outbound.NewWorker(db.SQL(), db.Ent(), blobStore, func() config.RelayConfig { return holder.Get().Relay }, m, notificationService, cfg.Server.InstanceName, db.Backend())
 	bounceHandler := bounce.NewHandler(db.Ent(), blobStore, m)
 	spamChecker := spam.NewChecker(db.Ent(), func() config.SpamConfig { return holder.Get().Spam }, cfg.Server.PublicHostname)
 	tlsConfig, err := certs.TLSConfig(ctx, certs.Options{TLS: cfg.TLS, PublicHostname: cfg.Server.PublicHostname, Hostnames: cfg.InboundHostnames()})

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -14,11 +14,14 @@ import (
 )
 
 type Config struct {
-	Server        ServerConfig       `pkl:"server" json:"server"`
-	SMTP          SMTPConfig         `pkl:"smtp" json:"smtp"`
-	IMAP          IMAPConfig         `pkl:"imap" json:"imap"`
-	Submission    SubmissionConfig   `pkl:"submission" json:"submission"`
-	Relay         RelayConfig        `pkl:"relay" json:"relay"`
+	Server     ServerConfig     `pkl:"server" json:"server"`
+	SMTP       SMTPConfig       `pkl:"smtp" json:"smtp"`
+	IMAP       IMAPConfig       `pkl:"imap" json:"imap"`
+	Submission SubmissionConfig `pkl:"submission" json:"submission"`
+	Relay      RelayConfig      `pkl:"relay" json:"relay"`
+	Database   DatabaseConfig   `pkl:"database" json:"database"`
+	// Postgres is kept for compatibility with configurations written before the
+	// generic database block was added.
 	Postgres      PostgresConfig     `pkl:"postgres" json:"postgres"`
 	S3            S3Config           `pkl:"s3" json:"s3"`
 	Logging       LoggingConfig      `pkl:"logging" json:"logging"`
@@ -107,6 +110,25 @@ func (c ServerConfig) ShutdownTimeout() time.Duration {
 
 type PostgresConfig struct {
 	DSN string `pkl:"dsn" json:"dsn"`
+}
+
+type DatabaseConfig struct {
+	Driver    string `pkl:"driver" json:"driver"`
+	DSN       string `pkl:"dsn" json:"dsn"`
+	AuthToken string `pkl:"auth_token" json:"auth_token"`
+}
+
+func (c Config) EffectiveDatabase() DatabaseConfig {
+	database := c.Database
+	if strings.TrimSpace(database.Driver) == "" {
+		database.Driver = "postgres"
+	}
+	if strings.TrimSpace(database.DSN) == "" && strings.EqualFold(database.Driver, "postgres") {
+		database.DSN = c.Postgres.DSN
+	}
+	database.Driver = strings.ToLower(strings.TrimSpace(database.Driver))
+	database.DSN = strings.TrimSpace(database.DSN)
+	return database
 }
 
 type S3Config struct {
@@ -368,8 +390,14 @@ func (c Config) Validate() error {
 	if c.SMTP.MaxInboundRecipients < 0 {
 		problems = append(problems, "smtp.max_inbound_recipients must be >= 0")
 	}
-	if strings.TrimSpace(c.Postgres.DSN) == "" {
-		problems = append(problems, "postgres.dsn is required")
+	database := c.EffectiveDatabase()
+	switch database.Driver {
+	case "postgres", "sqlite", "libsql":
+	default:
+		problems = append(problems, "database.driver must be postgres, sqlite, or libsql")
+	}
+	if database.DSN == "" {
+		problems = append(problems, "database.dsn is required")
 	}
 	if strings.TrimSpace(c.S3.Endpoint) == "" {
 		problems = append(problems, "s3.endpoint is required")
@@ -478,8 +506,8 @@ func (c Config) ReloadImpact(next *Config) ReloadImpact {
 	}
 
 	var changes []string
-	if c.Postgres != next.Postgres {
-		changes = append(changes, "postgres")
+	if c.EffectiveDatabase() != next.EffectiveDatabase() {
+		changes = append(changes, "database")
 	}
 	if c.S3 != next.S3 {
 		changes = append(changes, "s3")

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -25,7 +25,7 @@ func TestReloadImpactAllowsReloadableChanges(t *testing.T) {
 func TestReloadImpactDetectsStructuralChanges(t *testing.T) {
 	base := validConfig()
 	next := validConfig()
-	next.Postgres.DSN = "postgres://other"
+	next.Database.DSN = "postgres://other"
 
 	impact := base.ReloadImpact(&next)
 	if !impact.RequiresRestart() {
@@ -44,12 +44,33 @@ func validConfig() Config {
 		IMAP:       IMAPConfig{Addr: "127.0.0.1:1143"},
 		Submission: SubmissionConfig{StartTLSAddr: "127.0.0.1:1587", TLSAddr: "127.0.0.1:1465"},
 		Relay:      RelayConfig{Addr: "smtp.example.com:587"},
-		Postgres:   PostgresConfig{DSN: "postgres://localhost/haitatsu"},
+		Database:   DatabaseConfig{Driver: "postgres", DSN: "postgres://localhost/haitatsu"},
 		S3: S3Config{
 			Endpoint:        "localhost:9000",
 			Bucket:          "haitatsu",
 			AccessKeyID:     "minioadmin",
 			SecretAccessKey: "minioadmin",
 		},
+	}
+}
+
+func TestEffectiveDatabaseSupportsLegacyPostgresConfig(t *testing.T) {
+	cfg := Config{Postgres: PostgresConfig{DSN: "postgres://localhost/haitatsu"}}
+	got := cfg.EffectiveDatabase()
+	if got.Driver != "postgres" || got.DSN != cfg.Postgres.DSN {
+		t.Fatalf("effective database = %+v", got)
+	}
+}
+
+func TestValidateAcceptsSQLiteAndLibSQL(t *testing.T) {
+	for _, database := range []DatabaseConfig{
+		{Driver: "sqlite", DSN: "file:haitatsu.db"},
+		{Driver: "libsql", DSN: "libsql://example.turso.io", AuthToken: "secret"},
+	} {
+		cfg := validConfig()
+		cfg.Database = database
+		if err := cfg.Validate(); err != nil {
+			t.Errorf("validate %s: %v", database.Driver, err)
+		}
 	}
 }

--- a/internal/database/changebus.go
+++ b/internal/database/changebus.go
@@ -11,15 +11,31 @@ import (
 
 const changeChannel = "haitatsu_mail_changes"
 
-type ChangeBus struct {
+type ChangeBus interface {
+	Publish(ctx context.Context, payload []byte) error
+	Subscribe(ctx context.Context, handler func(payload []byte)) error
+}
+
+type postgresChangeBus struct {
 	db *sql.DB
 }
 
-func NewChangeBus(db *sql.DB) *ChangeBus {
-	return &ChangeBus{db: db}
+func NewChangeBus(db *sql.DB, backends ...Backend) ChangeBus {
+	backend := BackendPostgres
+	if len(backends) > 0 {
+		backend = backends[0]
+	}
+	switch backend {
+	case BackendLibSQL:
+		return &pollingChangeBus{db: db, interval: 250 * time.Millisecond}
+	case BackendSQLite:
+		return nil
+	default:
+		return &postgresChangeBus{db: db}
+	}
 }
 
-func (b *ChangeBus) Publish(ctx context.Context, payload []byte) error {
+func (b *postgresChangeBus) Publish(ctx context.Context, payload []byte) error {
 	if len(payload) > 7900 {
 		return errors.New("change payload too large for NOTIFY")
 	}
@@ -27,7 +43,7 @@ func (b *ChangeBus) Publish(ctx context.Context, payload []byte) error {
 	return err
 }
 
-func (b *ChangeBus) Subscribe(ctx context.Context, handler func(payload []byte)) error {
+func (b *postgresChangeBus) Subscribe(ctx context.Context, handler func(payload []byte)) error {
 	for {
 		err := b.listen(ctx, handler)
 		if ctx.Err() != nil {
@@ -43,7 +59,7 @@ func (b *ChangeBus) Subscribe(ctx context.Context, handler func(payload []byte))
 	}
 }
 
-func (b *ChangeBus) listen(ctx context.Context, handler func(payload []byte)) error {
+func (b *postgresChangeBus) listen(ctx context.Context, handler func(payload []byte)) error {
 	conn, err := b.db.Conn(ctx)
 	if err != nil {
 		return err
@@ -66,4 +82,82 @@ func (b *ChangeBus) listen(ctx context.Context, handler func(payload []byte)) er
 			handler([]byte(notification.Payload))
 		}
 	})
+}
+
+type pollingChangeBus struct {
+	db       *sql.DB
+	interval time.Duration
+}
+
+func (b *pollingChangeBus) Publish(ctx context.Context, payload []byte) error {
+	_, err := b.db.ExecContext(ctx, `INSERT INTO haitatsu_mail_changes (payload, created_at) VALUES (?, ?)`, payload, time.Now().UnixMilli())
+	return err
+}
+
+func (b *pollingChangeBus) Subscribe(ctx context.Context, handler func(payload []byte)) error {
+	var lastID int64
+	for {
+		id, err := b.latestID(ctx)
+		if err == nil {
+			lastID = id
+			break
+		}
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		case <-time.After(2 * time.Second):
+		}
+	}
+	ticker := time.NewTicker(b.interval)
+	defer ticker.Stop()
+	cleanup := time.NewTicker(10 * time.Minute)
+	defer cleanup.Stop()
+	for {
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		case <-ticker.C:
+			nextID, err := b.poll(ctx, lastID, handler)
+			if err == nil {
+				lastID = nextID
+			}
+		case <-cleanup.C:
+			_, _ = b.db.ExecContext(ctx, `DELETE FROM haitatsu_mail_changes WHERE created_at < ?`, time.Now().Add(-time.Hour).UnixMilli())
+		}
+	}
+}
+
+func (b *pollingChangeBus) latestID(ctx context.Context) (int64, error) {
+	var id int64
+	err := b.db.QueryRowContext(ctx, `SELECT COALESCE(MAX(id), 0) FROM haitatsu_mail_changes`).Scan(&id)
+	return id, err
+}
+
+func (b *pollingChangeBus) poll(ctx context.Context, afterID int64, handler func(payload []byte)) (int64, error) {
+	rows, err := b.db.QueryContext(ctx, `SELECT id, payload FROM haitatsu_mail_changes WHERE id > ? ORDER BY id LIMIT 256`, afterID)
+	if err != nil {
+		return afterID, err
+	}
+	defer rows.Close()
+
+	type change struct {
+		id      int64
+		payload []byte
+	}
+	var changes []change
+	for rows.Next() {
+		var item change
+		if err := rows.Scan(&item.id, &item.payload); err != nil {
+			return afterID, err
+		}
+		changes = append(changes, item)
+	}
+	if err := rows.Err(); err != nil {
+		return afterID, err
+	}
+	for _, item := range changes {
+		handler(item.payload)
+		afterID = item.id
+	}
+	return afterID, nil
 }

--- a/internal/database/database.go
+++ b/internal/database/database.go
@@ -2,69 +2,231 @@ package database
 
 import (
 	"context"
+	"crypto/rand"
 	"database/sql"
+	sqldriver "database/sql/driver"
+	"encoding/hex"
+	"fmt"
+	"strings"
 	"sync/atomic"
 	"time"
 
 	"entgo.io/ent/dialect"
 	entsql "entgo.io/ent/dialect/sql"
 	_ "github.com/jackc/pgx/v5/stdlib"
+	libsqlclient "github.com/tursodatabase/libsql-client-go/libsql"
+	_ "modernc.org/sqlite"
 
 	"github.com/zephyraoss/haitatsu/internal/config"
 	"github.com/zephyraoss/haitatsu/internal/database/ent"
 )
 
-const EntDialect = dialect.Postgres
+type Backend string
 
-const messageSearchIndexSQL = `
-CREATE INDEX IF NOT EXISTS messages_search_vector_idx
-ON messages USING GIN (to_tsvector('english', coalesce(subject, '') || ' ' || coalesce(from_addresses::text, '') || ' ' || coalesce(to_addresses::text, '') || ' ' || coalesce(cc_addresses::text, '') || ' ' || coalesce(text_body_extract, '') || ' ' || coalesce(html_body_extract, '') || ' ' || coalesce(attachments::text, '')))
-`
+const (
+	BackendPostgres Backend = "postgres"
+	BackendSQLite   Backend = "sqlite"
+	BackendLibSQL   Backend = "libsql"
+)
+
+func (b Backend) SQLiteFamily() bool {
+	return b == BackendSQLite || b == BackendLibSQL
+}
 
 type Client struct {
 	db             *sql.DB
 	ent            *ent.Client
+	backend        Backend
 	migrationsDone atomic.Bool
 }
 
-func Open(ctx context.Context, cfg config.PostgresConfig) (*Client, error) {
-	db, err := sql.Open("pgx", cfg.DSN)
+func Open(ctx context.Context, cfg config.DatabaseConfig) (*Client, error) {
+	backend := Backend(strings.ToLower(strings.TrimSpace(cfg.Driver)))
+	var db *sql.DB
+	var err error
+	switch backend {
+	case BackendPostgres:
+		db, err = sql.Open("pgx", cfg.DSN)
+	case BackendSQLite:
+		db, err = sql.Open("sqlite", sqliteDSN(cfg.DSN))
+	case BackendLibSQL:
+		options := make([]libsqlclient.Option, 0, 1)
+		if cfg.AuthToken != "" {
+			options = append(options, libsqlclient.WithAuthToken(cfg.AuthToken))
+		}
+		connector, connectorErr := libsqlclient.NewConnector(cfg.DSN, options...)
+		if connectorErr != nil {
+			return nil, fmt.Errorf("configure libsql connector: %w", connectorErr)
+		}
+		db = sql.OpenDB(&foreignKeyConnector{Connector: connector})
+	default:
+		return nil, fmt.Errorf("unsupported database driver %q", cfg.Driver)
+	}
 	if err != nil {
 		return nil, err
 	}
-	db.SetMaxOpenConns(50)
-	db.SetMaxIdleConns(10)
-	db.SetConnMaxLifetime(30 * time.Minute)
-	db.SetConnMaxIdleTime(5 * time.Minute)
+
+	configurePool(db, backend)
 	if err := db.PingContext(ctx); err != nil {
 		db.Close()
 		return nil, err
 	}
 
-	driver := entsql.OpenDB(dialect.Postgres, db)
-	return &Client{db: db, ent: ent.NewClient(ent.Driver(driver))}, nil
+	entDialect := dialect.Postgres
+	if backend.SQLiteFamily() {
+		entDialect = dialect.SQLite
+	}
+	driver := entsql.OpenDB(entDialect, db)
+	return &Client{db: db, ent: ent.NewClient(ent.Driver(driver)), backend: backend}, nil
+}
+
+type foreignKeyConnector struct {
+	sqldriver.Connector
+}
+
+func (c *foreignKeyConnector) Connect(ctx context.Context) (sqldriver.Conn, error) {
+	conn, err := c.Connector.Connect(ctx)
+	if err != nil {
+		return nil, err
+	}
+	if execer, ok := conn.(sqldriver.ExecerContext); ok {
+		if _, err := execer.ExecContext(ctx, `PRAGMA foreign_keys = ON`, nil); err != nil {
+			conn.Close()
+			return nil, fmt.Errorf("enable libsql foreign keys: %w", err)
+		}
+		return conn, nil
+	}
+	statement, err := conn.Prepare(`PRAGMA foreign_keys = ON`)
+	if err != nil {
+		conn.Close()
+		return nil, fmt.Errorf("prepare libsql foreign key pragma: %w", err)
+	}
+	defer statement.Close()
+	if _, err := statement.Exec(nil); err != nil {
+		conn.Close()
+		return nil, fmt.Errorf("enable libsql foreign keys: %w", err)
+	}
+	return conn, nil
+}
+
+func configurePool(db *sql.DB, backend Backend) {
+	switch backend {
+	case BackendPostgres:
+		db.SetMaxOpenConns(50)
+		db.SetMaxIdleConns(10)
+	case BackendSQLite:
+		db.SetMaxOpenConns(10)
+		db.SetMaxIdleConns(5)
+	case BackendLibSQL:
+		db.SetMaxOpenConns(20)
+		db.SetMaxIdleConns(5)
+	}
+	db.SetConnMaxLifetime(30 * time.Minute)
+	db.SetConnMaxIdleTime(5 * time.Minute)
+}
+
+func sqliteDSN(dsn string) string {
+	dsn = strings.TrimSpace(dsn)
+	if dsn == ":memory:" {
+		dsn = "file:haitatsu?mode=memory&cache=shared"
+	} else if !strings.HasPrefix(dsn, "file:") {
+		dsn = "file:" + dsn
+	}
+	separator := "?"
+	if strings.Contains(dsn, "?") {
+		separator = "&"
+	}
+	return dsn + separator + "_pragma=foreign_keys(1)&_pragma=journal_mode(WAL)&_pragma=busy_timeout(5000)&_time_format=sqlite"
 }
 
 const migrationLockKey = 7250316
 
 func (c *Client) RunMigrations(ctx context.Context) error {
-	lockConn, err := c.db.Conn(ctx)
+	release, err := c.acquireMigrationLock(ctx)
 	if err != nil {
 		return err
 	}
-	defer lockConn.Close()
-	if _, err := lockConn.ExecContext(ctx, `SELECT pg_advisory_lock($1)`, migrationLockKey); err != nil {
-		return err
-	}
-	defer lockConn.ExecContext(context.Background(), `SELECT pg_advisory_unlock($1)`, migrationLockKey)
+	defer release()
+
 	if err := c.ent.Schema.Create(ctx); err != nil {
 		return err
 	}
-	if err := c.runVersionedMigrations(ctx, versionedMigrations()); err != nil {
+	if err := c.runVersionedMigrations(ctx, versionedMigrations(c.backend)); err != nil {
 		return err
 	}
 	c.migrationsDone.Store(true)
 	return nil
+}
+
+func (c *Client) acquireMigrationLock(ctx context.Context) (func(), error) {
+	if c.backend == BackendPostgres {
+		lockConn, err := c.db.Conn(ctx)
+		if err != nil {
+			return nil, err
+		}
+		if _, err := lockConn.ExecContext(ctx, `SELECT pg_advisory_lock($1)`, migrationLockKey); err != nil {
+			lockConn.Close()
+			return nil, err
+		}
+		return func() {
+			releaseCtx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+			defer cancel()
+			_, _ = lockConn.ExecContext(releaseCtx, `SELECT pg_advisory_unlock($1)`, migrationLockKey)
+			_ = lockConn.Close()
+		}, nil
+	}
+
+	if _, err := c.db.ExecContext(ctx, `CREATE TABLE IF NOT EXISTS haitatsu_migration_lock (
+		id INTEGER PRIMARY KEY,
+		owner TEXT NOT NULL,
+		locked_until INTEGER NOT NULL
+	)`); err != nil {
+		return nil, err
+	}
+	if _, err := c.db.ExecContext(ctx, `INSERT INTO haitatsu_migration_lock (id, owner, locked_until) VALUES (1, '', 0) ON CONFLICT(id) DO NOTHING`); err != nil {
+		return nil, err
+	}
+	owner, err := randomLockOwner()
+	if err != nil {
+		return nil, err
+	}
+	for {
+		now := time.Now().Unix()
+		result, err := c.db.ExecContext(ctx, `UPDATE haitatsu_migration_lock SET owner = ?, locked_until = ? WHERE id = 1 AND locked_until < ?`, owner, now+300, now)
+		if err == nil {
+			changed, changedErr := result.RowsAffected()
+			if changedErr != nil {
+				return nil, fmt.Errorf("read migration lock result: %w", changedErr)
+			}
+			if changed == 1 {
+				return func() {
+					releaseCtx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+					defer cancel()
+					_, _ = c.db.ExecContext(releaseCtx, `UPDATE haitatsu_migration_lock SET owner = '', locked_until = 0 WHERE id = 1 AND owner = ?`, owner)
+				}, nil
+			}
+		} else if !sqliteBusy(err) {
+			return nil, fmt.Errorf("acquire migration lock: %w", err)
+		}
+		select {
+		case <-ctx.Done():
+			return nil, ctx.Err()
+		case <-time.After(250 * time.Millisecond):
+		}
+	}
+}
+
+func sqliteBusy(err error) bool {
+	message := strings.ToLower(err.Error())
+	return strings.Contains(message, "database is locked") || strings.Contains(message, "database is busy")
+}
+
+func randomLockOwner() (string, error) {
+	value := make([]byte, 16)
+	if _, err := rand.Read(value); err != nil {
+		return "", err
+	}
+	return hex.EncodeToString(value), nil
 }
 
 func (c *Client) Health(ctx context.Context) error {
@@ -93,4 +255,15 @@ func (c *Client) Ent() *ent.Client {
 
 func (c *Client) SQL() *sql.DB {
 	return c.db
+}
+
+func (c *Client) Backend() Backend {
+	return c.backend
+}
+
+func (c *Client) Dialect() string {
+	if c.backend.SQLiteFamily() {
+		return dialect.SQLite
+	}
+	return dialect.Postgres
 }

--- a/internal/database/database_test.go
+++ b/internal/database/database_test.go
@@ -1,0 +1,209 @@
+package database
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/zephyraoss/haitatsu/internal/config"
+)
+
+func TestSQLiteOpenAndMigrate(t *testing.T) {
+	ctx := context.Background()
+	client, err := Open(ctx, config.DatabaseConfig{
+		Driver: "sqlite",
+		DSN:    filepath.Join(t.TempDir(), "haitatsu.db"),
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer client.Close()
+
+	if err := client.RunMigrations(ctx); err != nil {
+		t.Fatal(err)
+	}
+	if !client.MigrationsDone() {
+		t.Fatal("migrations were not marked complete")
+	}
+	if client.Backend() != BackendSQLite || client.Dialect() != "sqlite3" {
+		t.Fatalf("backend = %q, dialect = %q", client.Backend(), client.Dialect())
+	}
+
+	var migrationCount int
+	if err := client.db.QueryRowContext(ctx, `SELECT count(*) FROM schema_migrations`).Scan(&migrationCount); err != nil {
+		t.Fatal(err)
+	}
+	if migrationCount != 4 {
+		t.Fatalf("migration count = %d, want 4", migrationCount)
+	}
+
+	if bus := NewChangeBus(client.db, client.backend); bus != nil {
+		t.Fatal("local SQLite should use in-process notifications only")
+	}
+	bus := &pollingChangeBus{db: client.db}
+	lastID, err := bus.latestID(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	payload := []byte(`{"kind":"exists"}`)
+	if err := bus.Publish(ctx, payload); err != nil {
+		t.Fatal(err)
+	}
+	var got []byte
+	lastID, err = bus.poll(ctx, lastID, func(value []byte) { got = append([]byte(nil), value...) })
+	if err != nil {
+		t.Fatal(err)
+	}
+	if lastID == 0 || string(got) != string(payload) {
+		t.Fatalf("last id = %d, payload = %q", lastID, got)
+	}
+}
+
+func TestSQLiteMigrationsAreRepeatable(t *testing.T) {
+	ctx := context.Background()
+	path := filepath.Join(t.TempDir(), "haitatsu.db")
+	for range 2 {
+		client, err := Open(ctx, config.DatabaseConfig{Driver: "sqlite", DSN: path})
+		if err != nil {
+			t.Fatal(err)
+		}
+		if err := client.RunMigrations(ctx); err != nil {
+			client.Close()
+			t.Fatal(err)
+		}
+		client.Close()
+	}
+}
+
+func TestSQLiteUIDBackfillMigration(t *testing.T) {
+	ctx := context.Background()
+	client, err := Open(ctx, config.DatabaseConfig{Driver: "sqlite", DSN: filepath.Join(t.TempDir(), "haitatsu.db")})
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer client.Close()
+	if err := client.RunMigrations(ctx); err != nil {
+		t.Fatal(err)
+	}
+
+	createdAt := time.Date(2025, 7, 4, 12, 30, 0, 0, time.UTC)
+	mailbox, err := client.Ent().Mailbox.Create().SetPrimaryAddress("backfill@example.test").Save(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	folder, err := client.Ent().Folder.Create().SetMailboxID(mailbox.ID).SetName("INBOX").SetUIDValidity(1).SetCreatedAt(createdAt).Save(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	message, err := client.Ent().Message.Create().SetTraceID("trace").SetBlobKey("message.eml").SetSha256("sha256").SetSizeBytes(10).Save(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	mailboxMessage, err := client.Ent().MailboxMessage.Create().SetMailboxID(mailbox.ID).SetMessageID(message.ID).SetFolderID(folder.ID).SetUID(0).SetOriginalRcpt(mailbox.PrimaryAddress).SetBaseRcpt(mailbox.PrimaryAddress).Save(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	tx, err := client.db.BeginTx(ctx, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := versionedMigrations(BackendSQLite)[1].Apply(ctx, tx); err != nil {
+		_ = tx.Rollback()
+		t.Fatal(err)
+	}
+	if err := tx.Commit(); err != nil {
+		t.Fatal(err)
+	}
+
+	folder, err = client.Ent().Folder.Get(ctx, folder.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	mailboxMessage, err = client.Ent().MailboxMessage.Get(ctx, mailboxMessage.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if folder.UIDValidity != uint32(createdAt.Unix()) || folder.UIDNext != 2 || mailboxMessage.UID != 1 {
+		t.Fatalf("folder = %+v, message uid = %d", folder, mailboxMessage.UID)
+	}
+}
+
+func TestLibSQLConnectorUsesSQLiteDialect(t *testing.T) {
+	ctx := context.Background()
+	client, err := Open(ctx, config.DatabaseConfig{
+		Driver: "libsql",
+		DSN:    "file:" + filepath.Join(t.TempDir(), "haitatsu.db"),
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer client.Close()
+	if err := client.RunMigrations(ctx); err != nil {
+		t.Fatal(err)
+	}
+	if client.Backend() != BackendLibSQL || client.Dialect() != "sqlite3" {
+		t.Fatalf("backend = %q, dialect = %q", client.Backend(), client.Dialect())
+	}
+}
+
+func TestLibSQLRemote(t *testing.T) {
+	endpoint := os.Getenv("HAITATSU_TEST_LIBSQL_URL")
+	if endpoint == "" {
+		t.Skip("HAITATSU_TEST_LIBSQL_URL is not set")
+	}
+	ctx := context.Background()
+	client, err := Open(ctx, config.DatabaseConfig{
+		Driver:    "libsql",
+		DSN:       endpoint,
+		AuthToken: os.Getenv("HAITATSU_TEST_LIBSQL_AUTH_TOKEN"),
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer client.Close()
+	if err := client.RunMigrations(ctx); err != nil {
+		t.Fatal(err)
+	}
+	address := fmt.Sprintf("libsql-test-%d@example.test", time.Now().UnixNano())
+	mailbox, err := client.Ent().Mailbox.Create().SetPrimaryAddress(address).Save(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := client.Ent().Mailbox.Get(ctx, mailbox.ID); err != nil {
+		t.Fatal(err)
+	}
+	message, err := client.Ent().Message.Create().SetTraceID("trace").SetBlobKey("message.eml").SetSha256("sha256").SetSizeBytes(10).SetSubject("remote search needle").Save(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var messageID string
+	if err := client.db.QueryRowContext(ctx, `SELECT messages.id FROM messages JOIN messages_search ON messages_search.message_id = messages.id WHERE messages_search MATCH ?`, `"needle"`).Scan(&messageID); err != nil {
+		t.Fatal(err)
+	}
+	if messageID != message.ID {
+		t.Fatalf("search result = %q, want %q", messageID, message.ID)
+	}
+
+	bus, ok := NewChangeBus(client.db, client.backend).(*pollingChangeBus)
+	if !ok {
+		t.Fatal("libSQL did not use the polling change bus")
+	}
+	lastID, err := bus.latestID(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := bus.Publish(ctx, []byte(`{"kind":"exists"}`)); err != nil {
+		t.Fatal(err)
+	}
+	delivered := false
+	if _, err := bus.poll(ctx, lastID, func([]byte) { delivered = true }); err != nil {
+		t.Fatal(err)
+	}
+	if !delivered {
+		t.Fatal("libSQL change bus did not deliver the published change")
+	}
+}

--- a/internal/database/migrations.go
+++ b/internal/database/migrations.go
@@ -12,6 +12,39 @@ type Migration struct {
 	Apply func(ctx context.Context, tx *sql.Tx) error
 }
 
+const messageSearchIndexSQL = `
+CREATE INDEX IF NOT EXISTS messages_search_vector_idx
+ON messages USING GIN (to_tsvector('english', coalesce(subject, '') || ' ' || coalesce(from_addresses::text, '') || ' ' || coalesce(to_addresses::text, '') || ' ' || coalesce(cc_addresses::text, '') || ' ' || coalesce(text_body_extract, '') || ' ' || coalesce(html_body_extract, '') || ' ' || coalesce(attachments::text, '')))
+`
+
+var sqliteMessageSearchSQL = []string{
+	`CREATE VIRTUAL TABLE IF NOT EXISTS messages_search USING fts5(
+		message_id UNINDEXED,
+		subject,
+		from_addresses,
+		to_addresses,
+		cc_addresses,
+		text_body_extract,
+		html_body_extract,
+		attachments
+	)`,
+	`INSERT INTO messages_search (message_id, subject, from_addresses, to_addresses, cc_addresses, text_body_extract, html_body_extract, attachments)
+	 SELECT id, subject, from_addresses, to_addresses, cc_addresses, text_body_extract, html_body_extract, attachments
+	 FROM messages`,
+	`CREATE TRIGGER IF NOT EXISTS messages_search_insert AFTER INSERT ON messages BEGIN
+		INSERT INTO messages_search (message_id, subject, from_addresses, to_addresses, cc_addresses, text_body_extract, html_body_extract, attachments)
+		VALUES (new.id, new.subject, new.from_addresses, new.to_addresses, new.cc_addresses, new.text_body_extract, new.html_body_extract, new.attachments);
+	END`,
+	`CREATE TRIGGER IF NOT EXISTS messages_search_update AFTER UPDATE OF subject, from_addresses, to_addresses, cc_addresses, text_body_extract, html_body_extract, attachments ON messages BEGIN
+		DELETE FROM messages_search WHERE message_id = old.id;
+		INSERT INTO messages_search (message_id, subject, from_addresses, to_addresses, cc_addresses, text_body_extract, html_body_extract, attachments)
+		VALUES (new.id, new.subject, new.from_addresses, new.to_addresses, new.cc_addresses, new.text_body_extract, new.html_body_extract, new.attachments);
+	END`,
+	`CREATE TRIGGER IF NOT EXISTS messages_search_delete AFTER DELETE ON messages BEGIN
+		DELETE FROM messages_search WHERE message_id = old.id;
+	END`,
+}
+
 func (c *Client) runVersionedMigrations(ctx context.Context, migrations []Migration) error {
 	for _, migration := range migrations {
 		applied, err := c.migrationApplied(ctx, migration.ID)
@@ -29,7 +62,7 @@ func (c *Client) runVersionedMigrations(ctx context.Context, migrations []Migrat
 			_ = tx.Rollback()
 			return fmt.Errorf("migration %s: %w", migration.ID, err)
 		}
-		if _, err := tx.ExecContext(ctx, `INSERT INTO schema_migrations (id, applied_at) VALUES ($1, $2)`, migration.ID, time.Now().UTC()); err != nil {
+		if _, err := tx.ExecContext(ctx, c.query(`INSERT INTO schema_migrations (id, applied_at) VALUES ($1, $2)`, `INSERT INTO schema_migrations (id, applied_at) VALUES (?, ?)`), migration.ID, time.Now().UTC()); err != nil {
 			_ = tx.Rollback()
 			return fmt.Errorf("record migration %s: %w", migration.ID, err)
 		}
@@ -42,7 +75,7 @@ func (c *Client) runVersionedMigrations(ctx context.Context, migrations []Migrat
 
 func (c *Client) migrationApplied(ctx context.Context, id string) (bool, error) {
 	var count int
-	if err := c.db.QueryRowContext(ctx, `SELECT count(*) FROM schema_migrations WHERE id = $1`, id).Scan(&count); err != nil {
+	if err := c.db.QueryRowContext(ctx, c.query(`SELECT count(*) FROM schema_migrations WHERE id = $1`, `SELECT count(*) FROM schema_migrations WHERE id = ?`), id).Scan(&count); err != nil {
 		return false, err
 	}
 	return count > 0, nil
@@ -57,17 +90,54 @@ func execAll(ctx context.Context, tx *sql.Tx, statements ...string) error {
 	return nil
 }
 
-func versionedMigrations() []Migration {
+func (c *Client) query(postgres string, sqlite string) string {
+	if c.backend.SQLiteFamily() {
+		return sqlite
+	}
+	return postgres
+}
+
+func versionedMigrations(backend Backend) []Migration {
+	sqliteFamily := backend.SQLiteFamily()
 	return []Migration{
 		{
 			ID: "0001_message_search_index",
 			Apply: func(ctx context.Context, tx *sql.Tx) error {
+				if sqliteFamily {
+					return execAll(ctx, tx, sqliteMessageSearchSQL...)
+				}
 				return execAll(ctx, tx, messageSearchIndexSQL)
 			},
 		},
 		{
 			ID: "0002_backfill_imap_uids",
 			Apply: func(ctx context.Context, tx *sql.Tx) error {
+				if sqliteFamily {
+					return execAll(ctx, tx,
+						`UPDATE folders SET uid_validity = CAST(strftime('%s', created_at) AS INTEGER) WHERE uid_validity <= 1`,
+						`UPDATE labels SET uid_validity = CAST(strftime('%s', created_at) AS INTEGER) WHERE uid_validity <= 1`,
+						`WITH numbered AS (
+						   SELECT id, folder_id, row_number() OVER (PARTITION BY folder_id ORDER BY created_at, id) AS seq
+						   FROM mailbox_messages WHERE uid = 0
+						 )
+						 UPDATE mailbox_messages SET uid = (
+						   SELECT folders.uid_next + numbered.seq - 1
+						   FROM numbered JOIN folders ON folders.id = numbered.folder_id
+						   WHERE numbered.id = mailbox_messages.id
+						 ) WHERE id IN (SELECT id FROM numbered)`,
+						`UPDATE folders SET uid_next = COALESCE((SELECT max(uid) + 1 FROM mailbox_messages WHERE folder_id = folders.id), 1)`,
+						`WITH numbered AS (
+						   SELECT id, label_id, row_number() OVER (PARTITION BY label_id ORDER BY created_at, id) AS seq
+						   FROM mailbox_message_labels WHERE uid = 0
+						 )
+						 UPDATE mailbox_message_labels SET uid = (
+						   SELECT labels.uid_next + numbered.seq - 1
+						   FROM numbered JOIN labels ON labels.id = numbered.label_id
+						   WHERE numbered.id = mailbox_message_labels.id
+						 ) WHERE id IN (SELECT id FROM numbered)`,
+						`UPDATE labels SET uid_next = COALESCE((SELECT max(uid) + 1 FROM mailbox_message_labels WHERE label_id = labels.id), 1)`,
+					)
+				}
 				return execAll(ctx, tx,
 					`UPDATE folders SET uid_validity = EXTRACT(EPOCH FROM created_at)::bigint WHERE uid_validity <= 1`,
 					`UPDATE labels SET uid_validity = EXTRACT(EPOCH FROM created_at)::bigint WHERE uid_validity <= 1`,
@@ -93,11 +163,35 @@ func versionedMigrations() []Migration {
 		{
 			ID: "0003_recompute_used_bytes",
 			Apply: func(ctx context.Context, tx *sql.Tx) error {
+				if sqliteFamily {
+					return execAll(ctx, tx,
+						`UPDATE mailboxes SET used_bytes = COALESCE((
+						   SELECT sum(messages.size_bytes) FROM mailbox_messages JOIN messages ON messages.id = mailbox_messages.message_id
+						   WHERE mailbox_messages.mailbox_id = mailboxes.id AND mailbox_messages.deleted_at IS NULL
+						 ), 0)`,
+					)
+				}
 				return execAll(ctx, tx,
 					`UPDATE mailboxes mb SET used_bytes = COALESCE((
 					   SELECT sum(m.size_bytes) FROM mailbox_messages mm JOIN messages m ON m.id = mm.message_id
 					   WHERE mm.mailbox_id = mb.id AND mm.deleted_at IS NULL
 					 ), 0)`,
+				)
+			},
+		},
+		{
+			ID: "0004_sqlite_change_bus",
+			Apply: func(ctx context.Context, tx *sql.Tx) error {
+				if !sqliteFamily {
+					return nil
+				}
+				return execAll(ctx, tx,
+					`CREATE TABLE IF NOT EXISTS haitatsu_mail_changes (
+					   id INTEGER PRIMARY KEY AUTOINCREMENT,
+					   payload BLOB NOT NULL,
+					   created_at INTEGER NOT NULL
+					 )`,
+					`CREATE INDEX IF NOT EXISTS haitatsu_mail_changes_created_at ON haitatsu_mail_changes (created_at)`,
 				)
 			},
 		},

--- a/internal/health/health.go
+++ b/internal/health/health.go
@@ -35,7 +35,7 @@ func (c *Checker) Ready(ctx context.Context) error {
 		return fmt.Errorf("migrations not complete")
 	}
 	if err := c.database.Health(ctx); err != nil {
-		return fmt.Errorf("postgres: %w", err)
+		return fmt.Errorf("database: %w", err)
 	}
 	if err := c.storage.Health(ctx); err != nil {
 		return fmt.Errorf("s3: %w", err)

--- a/internal/importexport/export.go
+++ b/internal/importexport/export.go
@@ -9,6 +9,7 @@ import (
 	"os"
 	"time"
 
+	"github.com/zephyraoss/haitatsu/internal/database"
 	"github.com/zephyraoss/haitatsu/internal/database/ent"
 	"github.com/zephyraoss/haitatsu/internal/database/ent/exportjob"
 	"github.com/zephyraoss/haitatsu/internal/database/ent/mailboxmessage"
@@ -30,6 +31,7 @@ type ExportWorker struct {
 	store    Store
 	events   *events.Service
 	workerID string
+	backend  database.Backend
 }
 
 type exportJob struct {
@@ -37,8 +39,12 @@ type exportJob struct {
 	MailboxID string
 }
 
-func NewExportWorker(db *sql.DB, client *ent.Client, store Store, events *events.Service, workerID string) *ExportWorker {
-	return &ExportWorker{db: db, client: client, store: store, events: events, workerID: workerID}
+func NewExportWorker(db *sql.DB, client *ent.Client, store Store, events *events.Service, workerID string, backends ...database.Backend) *ExportWorker {
+	backend := database.BackendPostgres
+	if len(backends) > 0 {
+		backend = backends[0]
+	}
+	return &ExportWorker{db: db, client: client, store: store, events: events, workerID: workerID, backend: backend}
 }
 
 func (w *ExportWorker) Run(ctx context.Context, concurrency int) {
@@ -118,7 +124,7 @@ func (w *ExportWorker) claim(ctx context.Context) (exportJob, string, bool, erro
 	}
 	defer tx.Rollback()
 
-	row := tx.QueryRowContext(ctx, `
+	query := `
 UPDATE export_jobs SET locked_by = $1, locked_until = $2, status = 'processing', updated_at = NOW()
 WHERE id = (
   SELECT id FROM export_jobs
@@ -128,7 +134,24 @@ WHERE id = (
   LIMIT 1
 )
 RETURNING id, mailbox_id
-`, owner, time.Now().Add(jobLeaseDuration))
+`
+	now := time.Now().UTC()
+	args := []any{owner, now.Add(jobLeaseDuration)}
+	if w.backend.SQLiteFamily() {
+		query = `
+UPDATE export_jobs SET locked_by = ?, locked_until = ?, status = 'processing', updated_at = ?
+WHERE id = (
+  SELECT id FROM export_jobs
+  WHERE status = 'queued' AND (locked_until IS NULL OR datetime(locked_until) <= datetime(?))
+  ORDER BY created_at
+  LIMIT 1
+)
+AND status = 'queued' AND (locked_until IS NULL OR datetime(locked_until) <= datetime(?))
+RETURNING id, mailbox_id
+`
+		args = []any{owner, now.Add(jobLeaseDuration), now, now, now}
+	}
+	row := tx.QueryRowContext(ctx, query, args...)
 
 	var job exportJob
 	if err := row.Scan(&job.ID, &job.MailboxID); err != nil {

--- a/internal/importexport/import.go
+++ b/internal/importexport/import.go
@@ -19,6 +19,7 @@ import (
 	"github.com/emersion/go-imap/v2"
 	"github.com/emersion/go-imap/v2/imapclient"
 
+	"github.com/zephyraoss/haitatsu/internal/database"
 	"github.com/zephyraoss/haitatsu/internal/database/ent"
 	"github.com/zephyraoss/haitatsu/internal/database/ent/folder"
 	"github.com/zephyraoss/haitatsu/internal/database/ent/importjob"
@@ -43,6 +44,7 @@ type ImportWorker struct {
 	mail     *mailstore.Store
 	events   *events.Service
 	workerID string
+	backend  database.Backend
 }
 
 type importJob struct {
@@ -52,8 +54,12 @@ type importJob struct {
 	Source     map[string]any
 }
 
-func NewImportWorker(db *sql.DB, client *ent.Client, store Store, mail *mailstore.Store, events *events.Service, workerID string) *ImportWorker {
-	return &ImportWorker{db: db, client: client, store: store, mail: mail, events: events, workerID: workerID}
+func NewImportWorker(db *sql.DB, client *ent.Client, store Store, mail *mailstore.Store, events *events.Service, workerID string, backends ...database.Backend) *ImportWorker {
+	backend := database.BackendPostgres
+	if len(backends) > 0 {
+		backend = backends[0]
+	}
+	return &ImportWorker{db: db, client: client, store: store, mail: mail, events: events, workerID: workerID, backend: backend}
 }
 
 func (w *ImportWorker) mailStore() *mailstore.Store {
@@ -122,7 +128,7 @@ func (w *ImportWorker) claim(ctx context.Context) (importJob, string, bool, erro
 	}
 	defer tx.Rollback()
 
-	row := tx.QueryRowContext(ctx, `
+	query := `
 UPDATE import_jobs SET locked_by = $1, locked_until = $2, status = 'processing', updated_at = NOW()
 WHERE id = (
   SELECT id FROM import_jobs
@@ -132,7 +138,24 @@ WHERE id = (
   LIMIT 1
 )
 RETURNING id, mailbox_id, source_type, source
-`, owner, time.Now().Add(jobLeaseDuration))
+`
+	now := time.Now().UTC()
+	args := []any{owner, now.Add(jobLeaseDuration)}
+	if w.backend.SQLiteFamily() {
+		query = `
+UPDATE import_jobs SET locked_by = ?, locked_until = ?, status = 'processing', updated_at = ?
+WHERE id = (
+  SELECT id FROM import_jobs
+  WHERE status = 'queued' AND (locked_until IS NULL OR datetime(locked_until) <= datetime(?))
+  ORDER BY created_at
+  LIMIT 1
+)
+AND status = 'queued' AND (locked_until IS NULL OR datetime(locked_until) <= datetime(?))
+RETURNING id, mailbox_id, source_type, source
+`
+		args = []any{owner, now.Add(jobLeaseDuration), now, now, now}
+	}
+	row := tx.QueryRowContext(ctx, query, args...)
 
 	var job importJob
 	var source []byte

--- a/internal/importexport/worker_test.go
+++ b/internal/importexport/worker_test.go
@@ -15,10 +15,12 @@ import (
 	entsql "entgo.io/ent/dialect/sql"
 	_ "modernc.org/sqlite"
 
+	"github.com/zephyraoss/haitatsu/internal/database"
 	"github.com/zephyraoss/haitatsu/internal/database/ent"
 	entfolder "github.com/zephyraoss/haitatsu/internal/database/ent/folder"
 	"github.com/zephyraoss/haitatsu/internal/database/ent/mailboxmessage"
 	"github.com/zephyraoss/haitatsu/internal/ids"
+	"github.com/zephyraoss/haitatsu/internal/testutil"
 )
 
 type fakeStore struct {
@@ -91,6 +93,37 @@ func seedMailbox(t *testing.T, client *ent.Client) *ent.Mailbox {
 
 func rawMessage(subject string) []byte {
 	return []byte("From: sender@example.com\r\nTo: rcpt@example.com\r\nSubject: " + subject + "\r\nMessage-ID: <" + subject + "@example.com>\r\n\r\nbody of " + subject + "\r\n")
+}
+
+func TestClaimSQLiteImportAndExportJobs(t *testing.T) {
+	ctx := context.Background()
+	client, db := testutil.NewClient(t)
+	imported, err := client.ImportJob.Create().SetMailboxID("mailbox").SetSourceType("maildir").SetSource(map[string]any{"path": "/mail"}).Save(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	exported, err := client.ExportJob.Create().SetMailboxID("mailbox").Save(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	importWorker := &ImportWorker{db: db, client: client, workerID: "worker", backend: database.BackendSQLite}
+	importJob, _, ok, err := importWorker.claim(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !ok || importJob.ID != imported.ID {
+		t.Fatalf("import claim = %+v, ok = %v", importJob, ok)
+	}
+
+	exportWorker := &ExportWorker{db: db, client: client, workerID: "worker", backend: database.BackendSQLite}
+	exportJob, _, ok, err := exportWorker.claim(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !ok || exportJob.ID != exported.ID {
+		t.Fatalf("export claim = %+v, ok = %v", exportJob, ok)
+	}
 }
 
 func writeMaildirMessage(t *testing.T, root string, rel string, raw []byte) {

--- a/internal/outbound/relay.go
+++ b/internal/outbound/relay.go
@@ -13,6 +13,7 @@ import (
 	"time"
 
 	"github.com/zephyraoss/haitatsu/internal/config"
+	"github.com/zephyraoss/haitatsu/internal/database"
 	"github.com/zephyraoss/haitatsu/internal/database/ent"
 	"github.com/zephyraoss/haitatsu/internal/database/ent/message"
 	"github.com/zephyraoss/haitatsu/internal/metrics"
@@ -36,6 +37,7 @@ type Worker struct {
 	metrics  *metrics.Metrics
 	notifier Notifier
 	workerID string
+	backend  database.Backend
 	send     Sender
 }
 
@@ -55,8 +57,12 @@ type deliveryResult struct {
 	Response           string
 }
 
-func NewWorker(db *sql.DB, client *ent.Client, store RelayStore, cfg func() config.RelayConfig, metrics *metrics.Metrics, notifier Notifier, workerID string) *Worker {
-	return &Worker{db: db, client: client, store: store, cfg: cfg, metrics: metrics, notifier: notifier, workerID: workerID, send: sendViaRelay}
+func NewWorker(db *sql.DB, client *ent.Client, store RelayStore, cfg func() config.RelayConfig, metrics *metrics.Metrics, notifier Notifier, workerID string, backends ...database.Backend) *Worker {
+	backend := database.BackendPostgres
+	if len(backends) > 0 {
+		backend = backends[0]
+	}
+	return &Worker{db: db, client: client, store: store, cfg: cfg, metrics: metrics, notifier: notifier, workerID: workerID, backend: backend, send: sendViaRelay}
 }
 
 func (w *Worker) WithSender(send Sender) *Worker {
@@ -121,7 +127,7 @@ func (w *Worker) claim(ctx context.Context) (claimedJob, bool, error) {
 	}
 	defer tx.Rollback()
 
-	row := tx.QueryRowContext(ctx, `
+	query := `
 UPDATE outbound_jobs SET locked_by = $1, locked_until = $2, status = 'processing', updated_at = NOW()
 WHERE id = (
   SELECT id FROM outbound_jobs
@@ -133,7 +139,28 @@ WHERE id = (
   LIMIT 1
 )
 RETURNING id, mailbox_id, message_id, return_path, recipients, attempts
-`, w.workerID, time.Now().Add(5*time.Minute))
+`
+	now := time.Now().UTC()
+	args := []any{w.workerID, now.Add(5 * time.Minute)}
+	if w.backend.SQLiteFamily() {
+		query = `
+UPDATE outbound_jobs SET locked_by = ?, locked_until = ?, status = 'processing', updated_at = ?
+WHERE id = (
+  SELECT id FROM outbound_jobs
+  WHERE status IN ('queued', 'retry')
+    AND (next_attempt_at IS NULL OR datetime(next_attempt_at) <= datetime(?))
+    AND (locked_until IS NULL OR datetime(locked_until) <= datetime(?))
+  ORDER BY created_at
+  LIMIT 1
+)
+AND status IN ('queued', 'retry')
+AND (next_attempt_at IS NULL OR datetime(next_attempt_at) <= datetime(?))
+AND (locked_until IS NULL OR datetime(locked_until) <= datetime(?))
+RETURNING id, mailbox_id, message_id, return_path, recipients, attempts
+`
+		args = []any{w.workerID, now.Add(5 * time.Minute), now, now, now, now, now}
+	}
+	row := tx.QueryRowContext(ctx, query, args...)
 
 	var job claimedJob
 	var recipients []byte

--- a/internal/outbound/relay_test.go
+++ b/internal/outbound/relay_test.go
@@ -3,10 +3,12 @@ package outbound
 import (
 	"context"
 	"errors"
+	"os"
 	"testing"
 	"time"
 
 	"github.com/zephyraoss/haitatsu/internal/config"
+	"github.com/zephyraoss/haitatsu/internal/database"
 	"github.com/zephyraoss/haitatsu/internal/database/ent"
 	"github.com/zephyraoss/haitatsu/internal/metrics"
 	"github.com/zephyraoss/haitatsu/internal/testutil"
@@ -57,7 +59,7 @@ func TestFinishSchedulesRetryAndEventuallyFails(t *testing.T) {
 	client, _ := testutil.NewClient(t)
 	notifier := &recordingNotifier{}
 	cfg := config.RelayConfig{Addr: "relay:25", MaxAttempts: 2}
-	worker := NewWorker(nil, client, testutil.NewFakeStore(), func() config.RelayConfig { return cfg }, metrics.New(), notifier, "w1")
+	worker := NewWorker(nil, client, testutil.NewFakeStore(), func() config.RelayConfig { return cfg }, metrics.New(), notifier, "w1", database.BackendSQLite)
 	job, err := client.OutboundJob.Create().SetMailboxID("m").SetMessageID("msg").SetReturnPath("bounces+msg@example.test").SetRecipients([]string{"a@x.test"}).Save(ctx)
 	if err != nil {
 		t.Fatal(err)
@@ -83,6 +85,65 @@ func TestFinishSchedulesRetryAndEventuallyFails(t *testing.T) {
 	}
 }
 
+func TestClaimSQLiteOutboundJob(t *testing.T) {
+	ctx := context.Background()
+	client, db := testutil.NewClient(t)
+	created, err := client.OutboundJob.Create().
+		SetMailboxID("mailbox").
+		SetMessageID("message").
+		SetReturnPath("sender@example.test").
+		SetRecipients([]string{"recipient@example.test"}).
+		Save(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	worker := NewWorker(db, client, testutil.NewFakeStore(), func() config.RelayConfig { return config.RelayConfig{} }, metrics.New(), nil, "worker", database.BackendSQLite)
+	job, ok, err := worker.claim(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !ok || job.ID != created.ID || len(job.Recipients) != 1 {
+		t.Fatalf("claimed = %+v, ok = %v", job, ok)
+	}
+}
+
+func TestClaimLibSQLRemoteOutboundJob(t *testing.T) {
+	endpoint := os.Getenv("HAITATSU_TEST_LIBSQL_URL")
+	if endpoint == "" {
+		t.Skip("HAITATSU_TEST_LIBSQL_URL is not set")
+	}
+	ctx := context.Background()
+	dbClient, err := database.Open(ctx, config.DatabaseConfig{
+		Driver:    "libsql",
+		DSN:       endpoint,
+		AuthToken: os.Getenv("HAITATSU_TEST_LIBSQL_AUTH_TOKEN"),
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer dbClient.Close()
+	if err := dbClient.RunMigrations(ctx); err != nil {
+		t.Fatal(err)
+	}
+	created, err := dbClient.Ent().OutboundJob.Create().
+		SetMailboxID("mailbox").
+		SetMessageID("message").
+		SetReturnPath("sender@example.test").
+		SetRecipients([]string{"recipient@example.test"}).
+		Save(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	worker := NewWorker(dbClient.SQL(), dbClient.Ent(), testutil.NewFakeStore(), func() config.RelayConfig { return config.RelayConfig{} }, metrics.New(), nil, "worker", database.BackendLibSQL)
+	job, ok, err := worker.claim(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !ok || job.ID != created.ID {
+		t.Fatalf("claimed = %+v, ok = %v", job, ok)
+	}
+}
+
 func TestDeliverUsesInjectedSender(t *testing.T) {
 	ctx := context.Background()
 	client, _ := testutil.NewClient(t)
@@ -93,7 +154,7 @@ func TestDeliverUsesInjectedSender(t *testing.T) {
 	}
 	var gotFrom string
 	var gotRcpt []string
-	worker := NewWorker(nil, client, blobs, func() config.RelayConfig { return config.RelayConfig{Addr: "x"} }, metrics.New(), nil, "w").WithSender(func(_ context.Context, _ config.RelayConfig, from string, rcpt []string, _ []byte) error {
+	worker := NewWorker(nil, client, blobs, func() config.RelayConfig { return config.RelayConfig{Addr: "x"} }, metrics.New(), nil, "w", database.BackendSQLite).WithSender(func(_ context.Context, _ config.RelayConfig, from string, rcpt []string, _ []byte) error {
 		gotFrom, gotRcpt = from, rcpt
 		return nil
 	})

--- a/internal/webhooks/worker.go
+++ b/internal/webhooks/worker.go
@@ -14,6 +14,7 @@ import (
 	"time"
 
 	"github.com/zephyraoss/haitatsu/internal/config"
+	"github.com/zephyraoss/haitatsu/internal/database"
 	"github.com/zephyraoss/haitatsu/internal/database/ent"
 	"github.com/zephyraoss/haitatsu/internal/metrics"
 )
@@ -24,6 +25,7 @@ type Worker struct {
 	cfg      func() config.WebhookConfig
 	metrics  *metrics.Metrics
 	workerID string
+	backend  database.Backend
 	http     *http.Client
 }
 
@@ -35,8 +37,12 @@ type eventJob struct {
 	Attempts  int
 }
 
-func NewWorker(db *sql.DB, client *ent.Client, cfg func() config.WebhookConfig, metrics *metrics.Metrics, workerID string) *Worker {
-	return &Worker{db: db, client: client, cfg: cfg, metrics: metrics, workerID: workerID, http: &http.Client{}}
+func NewWorker(db *sql.DB, client *ent.Client, cfg func() config.WebhookConfig, metrics *metrics.Metrics, workerID string, backends ...database.Backend) *Worker {
+	backend := database.BackendPostgres
+	if len(backends) > 0 {
+		backend = backends[0]
+	}
+	return &Worker{db: db, client: client, cfg: cfg, metrics: metrics, workerID: workerID, backend: backend, http: &http.Client{}}
 }
 
 func (w *Worker) Run(ctx context.Context, concurrency int) {
@@ -97,7 +103,7 @@ func (w *Worker) claim(ctx context.Context) (eventJob, bool, error) {
 	}
 	defer tx.Rollback()
 
-	row := tx.QueryRowContext(ctx, `
+	query := `
 UPDATE event_logs SET locked_by = $1, locked_until = $2, status = 'processing', updated_at = NOW()
 WHERE id = (
   SELECT id FROM event_logs
@@ -109,7 +115,28 @@ WHERE id = (
   LIMIT 1
 )
 RETURNING id, event_type, trace_id, payload, attempts
-`, w.workerID, time.Now().Add(5*time.Minute))
+`
+	now := time.Now().UTC()
+	args := []any{w.workerID, now.Add(5 * time.Minute)}
+	if w.backend.SQLiteFamily() {
+		query = `
+UPDATE event_logs SET locked_by = ?, locked_until = ?, status = 'processing', updated_at = ?
+WHERE id = (
+  SELECT id FROM event_logs
+  WHERE status IN ('queued', 'retry')
+    AND (next_attempt_at IS NULL OR datetime(next_attempt_at) <= datetime(?))
+    AND (locked_until IS NULL OR datetime(locked_until) <= datetime(?))
+  ORDER BY created_at
+  LIMIT 1
+)
+AND status IN ('queued', 'retry')
+AND (next_attempt_at IS NULL OR datetime(next_attempt_at) <= datetime(?))
+AND (locked_until IS NULL OR datetime(locked_until) <= datetime(?))
+RETURNING id, event_type, trace_id, payload, attempts
+`
+		args = []any{w.workerID, now.Add(5 * time.Minute), now, now, now, now, now}
+	}
+	row := tx.QueryRowContext(ctx, query, args...)
 
 	var job eventJob
 	var payload []byte

--- a/internal/webhooks/worker_test.go
+++ b/internal/webhooks/worker_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	"github.com/zephyraoss/haitatsu/internal/config"
+	"github.com/zephyraoss/haitatsu/internal/database"
 	"github.com/zephyraoss/haitatsu/internal/metrics"
 	"github.com/zephyraoss/haitatsu/internal/testutil"
 )
@@ -13,7 +14,7 @@ func TestFailSchedulesRetryWithBackoff(t *testing.T) {
 	ctx := context.Background()
 	client, _ := testutil.NewClient(t)
 	cfg := config.WebhookConfig{MaxAttempts: 3}
-	worker := NewWorker(nil, client, func() config.WebhookConfig { return cfg }, metrics.New(), "w")
+	worker := NewWorker(nil, client, func() config.WebhookConfig { return cfg }, metrics.New(), "w", database.BackendSQLite)
 	row, err := client.EventLog.Create().SetEventType("message.received").SetPayload(map[string]any{}).Save(ctx)
 	if err != nil {
 		t.Fatal(err)
@@ -42,6 +43,23 @@ func TestSignatureIsStable(t *testing.T) {
 	c := signature("other", "2025-01-01T00:00:00Z", []byte(`{"a":1}`))
 	if a != b || a == c || len(a) < 20 {
 		t.Fatal("signature mismatch")
+	}
+}
+
+func TestClaimSQLiteWebhookJob(t *testing.T) {
+	ctx := context.Background()
+	client, db := testutil.NewClient(t)
+	created, err := client.EventLog.Create().SetEventType("message.received").SetTraceID("trace").SetPayload(map[string]any{"id": "message"}).Save(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	worker := NewWorker(db, client, func() config.WebhookConfig { return config.WebhookConfig{} }, metrics.New(), "worker", database.BackendSQLite)
+	job, ok, err := worker.claim(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !ok || job.ID != created.ID || job.Payload["id"] != "message" {
+		t.Fatalf("claimed = %+v, ok = %v", job, ok)
 	}
 }
 


### PR DESCRIPTION
## Summary

- Add SQLite and remote libSQL support alongside PostgreSQL.
- Introduce generic database configuration with legacy PostgreSQL compatibility.
- Add backend-specific migrations, full-text search, connection settings, and change propagation.
- Update documentation, deployment examples, and tests for the new backends.

## Testing

- Added database, configuration, API search, import/export, relay, and webhook coverage.
- Added SQLite integration tests covering migrations and message search.
- Not run: full repository test suite.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds SQLite and libSQL database backends alongside PostgreSQL, with a new generic `database` config block. The old `postgres` block still works but is deprecated.

**Database backends**
- New `database` config block accepts `driver` (`postgres`, `sqlite`, or `libsql`), `dsn`, and `auth_token`.
- SQLite enables foreign keys, WAL mode, and a five-second busy timeout; keep it on a local persistent volume.
- libSQL supports Turso Cloud and self-hosted sqld over `http://`, `https://`, `ws://`, and `wss://`.
- PostgreSQL keeps GIN-backed full-text search; SQLite and libSQL use FTS5.
- IMAP IDLE notifications use polling every 250 ms for libSQL; local SQLite is single-process.

**Migration**
- Replace `postgres { dsn = "..." }` with `database { driver = "postgres", dsn = "..." }`; the old block still works.
- New `HAITATSU_DATABASE_DRIVER`, `HAITATSU_DATABASE_DSN`, and `HAITATSU_DATABASE_AUTH_TOKEN` env vars; `HAITATSU_POSTGRES_DSN` is a fallback.

<sup>Written for commit a79aabf447e04a49c114962d16dec8d8417afcf2. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/zephyraoss/haitatsu/pull/1?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

